### PR TITLE
Use a more tolerant sysname

### DIFF
--- a/include/linux/uts.h
+++ b/include/linux/uts.h
@@ -5,7 +5,7 @@
  * Defines for what uname() should return 
  */
 #ifndef UTS_SYSNAME
-#define UTS_SYSNAME "Linux"
+#define UTS_SYSNAME "ToleranUX"
 #endif
 
 #ifndef UTS_NODENAME


### PR DESCRIPTION
Uname shall not return the name of an oppressive kernel.